### PR TITLE
Support async stacktraces in MutableSharedFlow and MutableStateFlow

### DIFF
--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -51,3 +51,25 @@ exceeding the parallelism limit would eliminate this (likely expected) side effe
   associated coroutine dispatcher when it decides to park the thread
 - `CoroutineDispatcher.softLimitedParallelism` – an analogue of `.limitedParallelism` which supports
   parallelism compensation
+
+## Asynchronous stack traces for flows in the IDEA debugger
+
+The agent needs three entities to establish a proper asynchronous stack traces connection:
+- a capture point — method that indicates the stack trace that precedes the current stack trace;
+- an insertion point — method within the current stack trace;
+- a key — an object that is present in both points and is unique enough to bridge two stack traces properly.
+
+The key for MutableStateFlow is the element itself. For MutableSharedFlow, the element is wrapped into a unique object to prevent bridging mistakes when two equal elements are emitted from different places.
+
+Also, operators `debounce` and `sample` are supported. As they use an intermediary flow inside, the transferred values are wrapped and unwrapped the same way as in MutableSharedFlow.
+It means there may be all-library async stack traces between a stack trace containing `emit` and a stack trace containing `collect`.
+
+### API
+
+No new public methods are introduced; some logic was extracted to separate methods so that the debugger agent could instrument it properly:
+
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternal` -- wrapper class used to create a unique object for the debugger agent
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternal` -- returns passed argument by default; the agent instruments it to call `wrapInternalDebuggerCapture` instead
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternalDebuggerCapture` -- wraps passed arguments into a `FlowValueWrapperInternal`; only used after transformation
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternal` -- returns passed argument by default; the agent instruments it to call `unwrapInternalDebuggerCapture` instead
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternalDebuggerCapture` -- unwraps passed argument so it returns the original value; only used after transformation

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
@@ -1,0 +1,22 @@
+package kotlinx.coroutines.flow.internal
+
+/**
+ * Used by IDEA debugger agent to support asynchronous stack traces in flows.
+ * The agent requires a unique object present in both current and async stack traces,
+ * so, without a wrapper, if two flows, `f1` and `f2`, emit equal values,
+ * the agent could suggest `f1` as emitter for `f2.collect` and `f2` as emitter for `f1.collect`.
+ */
+internal class FlowValueWrapperInternal<T>(val value: T)
+
+internal fun <T> wrapInternal(value: T): T = value
+internal fun <T> unwrapInternal(value: T): T = value
+
+// debugger agent transforms wrapInternal so it returns wrapInternalDebuggerCapture(value) instead of just value
+private fun wrapInternalDebuggerCapture(value: Any?): Any = FlowValueWrapperInternal(value)
+
+// debugger agent transforms unwrapInternal so it returns unwrapInternalDebuggerCapture(value) instead of just value
+//
+// normally, value is always FlowValueWrapperInternal, but potentially instrumentation may start
+// in the middle of the execution (for example, when the debugger was attached to a running application),
+// and the emitted value hadn't been wrapped
+private fun unwrapInternalDebuggerCapture(value: Any?): Any? = (value as? FlowValueWrapperInternal<*>)?.value ?: value


### PR DESCRIPTION
I don't have rights to push to a branch in the base repository, and it seems it's not possible to merge to the same branch if it doesn't exist in base, so probably we can just review it as is and then push to the dedicated branch manually.

The change may be a bit controversial to be landed to upstream itself, as it involves extra method call (thus some performance impact). I expect it can also change a couple times over time. And, since the change is only useful when using IDEA debugger, putting it into the IDEA-specific fork seems more fit (well, as long as it exists).