### PR TITLE
Enhance support for async stack traces in flows

### DIFF
--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -79,6 +79,10 @@ Some logic related to instrumentation was extracted to separate methods so that 
 
 One internal method was added to `BufferedChannel`: `emitAllInternal`. This method ensures the value will be unwrapped in an insertion point.
 
+One internal method was added to `flow/Channels.kt`: `emitAllInternal`. It emits all values, like usual, but also considers wrapping/unwrapping supported in `BufferedChannel`.
+
+One internal method was added to `ChannelCoroutine`: `emitAllInternal` serves to bridge its delegate and the method above.
+
 One internal method was added to `BufferedChannelIterator`: `nextInternal` -- same as `next` but may return a wrapped value. It should only be used with a function that is capable of unwrapping the value (see `BufferedChannel.emitAll` and `BufferedChannelIterator.next`), so there's a guarantee a wrapped value will always unwrap before emitting.
 
 Why not just let `next` return a maybe wrapped value? That's because it is heavily used outside a currently supported scope. For example, one may just indirectly call it from a for-loop. In this case, unwrapping will never happen, and a user will get a handful of `ClassCastException`s.

--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -61,15 +61,29 @@ The agent needs three entities to establish a proper asynchronous stack traces c
 
 The key for MutableStateFlow is the element itself. For MutableSharedFlow, the element is wrapped into a unique object to prevent bridging mistakes when two equal elements are emitted from different places.
 
-Also, operators `debounce` and `sample` are supported. As they use an intermediary flow inside, the transferred values are wrapped and unwrapped the same way as in MutableSharedFlow.
+Most of the operators applicable to flows (such as `map`, `scan`, `debounce`, `buffer`) are supported. As some of them use an intermediary flow inside, the transferred values are wrapped and unwrapped the same way as in MutableSharedFlow.
 It means there may be all-library async stack traces between a stack trace containing `emit` and a stack trace containing `collect`.
+
+There is no support yet for many operators that heavily use `Channel`s inside (such as `timeout`), as well as for functions that convert flows to channels and vice versa (such as `produceIn`).
 
 ### API
 
-No new public methods are introduced; some logic was extracted to separate methods so that the debugger agent could instrument it properly:
+Some logic related to instrumentation was extracted to separate methods so that the debugger agent could instrument it properly:
 
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternal` -- wrapper class used to create a unique object for the debugger agent
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternal` -- returns passed argument by default; the agent instruments it to call `wrapInternalDebuggerCapture` instead
-- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternalDebuggerCapture` -- wraps passed arguments into a `FlowValueWrapperInternal`; only used after transformation
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternalDebuggerCaptureX` -- wraps passed arguments into a `FlowValueWrapperInternal`; only used after transformation.
+  `X` may mean `Strict` or `Lenient`. Both methods handle double-wrapping, which is always an error that is hard to investigate if it arises naturally.
+    - `Strict` throws an exception, thus allowing fail-fast strategy
+    - `Lenient` returns its argument without wrapping it again
+  Debugger agent decides which version to use based on IDE settings.
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternal` -- returns passed argument by default; the agent instruments it to call `unwrapInternalDebuggerCapture` instead
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternalDebuggerCapture` -- unwraps passed argument so it returns the original value; only used after transformation
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.emitInternal(FlowCollector, value)` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside
+
+One internal method was added to `BufferedChannelIterator`: `nextInternal` -- same as `next` but may return a wrapped value. It should only be used with a function that is capable of unwrapping the value (see `BufferedChannel.emitAll` and `BufferedChannelIterator.next`), so there's a guarantee a wrapped value will always unwrap before emitting.
+
+Why not just let `next` return a maybe wrapped value? That's because it is heavily used outside a currently supported scope. For example, one may just indirectly call it from a for-loop. In this case, unwrapping will never happen, and a user will get a handful of `ClassCastException`s.
+
+One public method was added to support `buffer` and operators that use it inside:
+- `ReceiveChannel.emitAll`. It encapsulates emitting values in `FlowCollector.emitAllImpl` and has a special implementation in `BufferedChannel`.

--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -72,11 +72,7 @@ Some logic related to instrumentation was extracted to separate methods so that 
 
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternal` -- wrapper class used to create a unique object for the debugger agent
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternal` -- returns passed argument by default; the agent instruments it to call `wrapInternalDebuggerCapture` instead
-- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternalDebuggerCaptureX` -- wraps passed arguments into a `FlowValueWrapperInternal`; only used after transformation.
-  `X` may mean `Strict` or `Lenient`. Both methods handle double-wrapping, which is always an error that is hard to investigate if it arises naturally.
-    - `Strict` throws an exception, thus allowing fail-fast strategy
-    - `Lenient` returns its argument without wrapping it again
-  Debugger agent decides which version to use based on IDE settings.
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.wrapInternalDebuggerCapture` -- wraps passed arguments into a `FlowValueWrapperInternal`; only used after transformation.
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternal` -- returns passed argument by default; the agent instruments it to call `unwrapInternalDebuggerCapture` instead
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternalDebuggerCapture` -- unwraps passed argument so it returns the original value; only used after transformation
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.emitInternal(FlowCollector, value)` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside

--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -75,7 +75,7 @@ Some logic related to instrumentation was extracted to separate methods so that 
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternalDebuggerCapture` -- unwraps passed argument so it returns the original value; only used after transformation
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapTyped` -- utility function served to ease casting to a real underlying type
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.emitInternal(FlowCollector, value)` -- alternative of a regular `FlowCollector.emit` that supports insertion points; if there is a `FlowCollector`, its `emit` call can be replaced with `emitInternal` so this case would also be supported for constructing async stack traces 
-- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.debuggerCapture` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside. `emitInternal` uses this method.
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.debuggerCapture` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside.
 
 One internal method was added to `BufferedChannel`: `emitAllInternal`. This method ensures the value will be unwrapped in an insertion point.
 

--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -61,10 +61,8 @@ The agent needs three entities to establish a proper asynchronous stack traces c
 
 The key for MutableStateFlow is the element itself. For MutableSharedFlow, the element is wrapped into a unique object to prevent bridging mistakes when two equal elements are emitted from different places.
 
-Most of the operators applicable to flows (such as `map`, `scan`, `debounce`, `buffer`) are supported. As some of them use an intermediary flow inside, the transferred values are wrapped and unwrapped the same way as in MutableSharedFlow.
+Most of the operators applicable to flows (such as `map`, `scan`, `debounce`, `timeout`, `buffer`) are supported. As some of them use an intermediary flow inside, the transferred values are wrapped and unwrapped the same way as in MutableSharedFlow.
 It means there may be all-library async stack traces between a stack trace containing `emit` and a stack trace containing `collect`.
-
-There is no support yet for many operators that use `Select` inside (such as `timeout`).
 
 ### API
 
@@ -76,7 +74,8 @@ Some logic related to instrumentation was extracted to separate methods so that 
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternal` -- returns passed argument by default; the agent instruments it to call `unwrapInternalDebuggerCapture` instead
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapInternalDebuggerCapture` -- unwraps passed argument so it returns the original value; only used after transformation
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.unwrapTyped` -- utility function served to ease casting to a real underlying type
-- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.emitInternal(FlowCollector, value)` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.emitInternal(FlowCollector, value)` -- alternative of a regular `FlowCollector.emit` that supports insertion points; if there is a `FlowCollector`, its `emit` call can be replaced with `emitInternal` so this case would also be supported for constructing async stack traces 
+- `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.debuggerCapture` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside. `emitInternal` uses this method.
 
 One internal method was added to `BufferedChannelIterator`: `nextInternal` -- same as `next` but may return a wrapped value. It should only be used with a function that is capable of unwrapping the value (see `BufferedChannel.emitAll` and `BufferedChannelIterator.next`), so there's a guarantee a wrapped value will always unwrap before emitting.
 
@@ -86,3 +85,5 @@ One public method was added to support `buffer` and operators that use it inside
 - `ReceiveChannel.emitAll`. It encapsulates emitting values in `FlowCollector.emitAllImpl` and has a special implementation in `BufferedChannel`.
 
 Changes were made to lambda parameter `onElementRetrieved` in `BufferedChannel<E>` methods: now they accept `Any?` instead of `E` because now they may be given a wrapped value.
+
+`SelectImplementation.complete` now uses `debuggerCapture` to properly propagate value that might come from flows. 

--- a/IntelliJ-patches.md
+++ b/IntelliJ-patches.md
@@ -77,12 +77,11 @@ Some logic related to instrumentation was extracted to separate methods so that 
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.emitInternal(FlowCollector, value)` -- alternative of a regular `FlowCollector.emit` that supports insertion points; if there is a `FlowCollector`, its `emit` call can be replaced with `emitInternal` so this case would also be supported for constructing async stack traces 
 - `kotlinx.coroutines.flow.internal.FlowValueWrapperInternalKt.debuggerCapture` -- common insertion point for a debugger agent; simplifies instrumentation; the value is always being unwrapped inside. `emitInternal` uses this method.
 
+One internal method was added to `BufferedChannel`: `emitAllInternal`. This method ensures the value will be unwrapped in an insertion point.
+
 One internal method was added to `BufferedChannelIterator`: `nextInternal` -- same as `next` but may return a wrapped value. It should only be used with a function that is capable of unwrapping the value (see `BufferedChannel.emitAll` and `BufferedChannelIterator.next`), so there's a guarantee a wrapped value will always unwrap before emitting.
 
 Why not just let `next` return a maybe wrapped value? That's because it is heavily used outside a currently supported scope. For example, one may just indirectly call it from a for-loop. In this case, unwrapping will never happen, and a user will get a handful of `ClassCastException`s.
-
-One public method was added to support `buffer` and operators that use it inside:
-- `ReceiveChannel.emitAll`. It encapsulates emitting values in `FlowCollector.emitAllImpl` and has a special implementation in `BufferedChannel`.
 
 Changes were made to lambda parameter `onElementRetrieved` in `BufferedChannel<E>` methods: now they accept `Any?` instead of `E` because now they may be given a wrapped value.
 

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -1543,7 +1543,7 @@ internal open class BufferedChannel<E>(
     @Suppress("UNCHECKED_CAST")
     private val onUndeliveredElementReceiveCancellationConstructor: OnCancellationConstructor? = onUndeliveredElement?.let {
         { select: SelectInstance<*>, _: Any?, element: Any? ->
-            { if (element !== CHANNEL_CLOSED) onUndeliveredElement.callUndeliveredElement(element as E, select.context) }
+            { if (element !== CHANNEL_CLOSED) onUndeliveredElement.callUndeliveredElement(unwrapTyped(element), select.context) }
         }
     }
 

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -683,7 +683,7 @@ internal open class BufferedChannel<E>(
             // If `receive()` decides to suspend, the corresponding
             // `suspend` function that creates a continuation is called.
             // The tail-call optimization is applied here.
-            onNoWaiterSuspend = { segm, i, r -> unwrapTyped(receiveOnNoWaiterSuspend(segm, i, r)) }
+            onNoWaiterSuspend = { segm, i, r -> receiveOnNoWaiterSuspend(segm, i, r) }
         )
 
     private suspend fun receiveOnNoWaiterSuspend(
@@ -706,8 +706,9 @@ internal open class BufferedChannel<E>(
             // not dispatched yet. In case `onUndeliveredElement` is
             // specified, we need to invoke it in the latter case.
             onElementRetrieved = { element ->
-                val onCancellation = onUndeliveredElement?.bindCancellationFun(unwrapTyped(element), cont.context)
-                cont.resume(element, onCancellation)
+                val unwrapped: E = unwrapTyped(element)
+                val onCancellation = onUndeliveredElement?.bindCancellationFun(unwrapped, cont.context)
+                cont.resume(unwrapped, onCancellation)
             },
             onClosed = { onClosedReceiveOnNoWaiterSuspend(cont) },
         )
@@ -737,7 +738,7 @@ internal open class BufferedChannel<E>(
             },
             onSuspend = { _, _, _ -> error("unexpected") },
             onClosed = { closed(closeCause) },
-            onNoWaiterSuspend = { segm, i, r -> unwrapTyped(receiveCatchingOnNoWaiterSuspend(segm, i, r)) }
+            onNoWaiterSuspend = { segm, i, r -> receiveCatchingOnNoWaiterSuspend(segm, i, r) }
         )
 
     private suspend fun receiveCatchingOnNoWaiterSuspend(

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -1513,7 +1513,7 @@ internal open class BufferedChannel<E>(
     private fun registerSelectForReceive(select: SelectInstance<*>, ignoredParam: Any?) =
         receiveImpl( // <-- this is an inline function
             waiter = select,
-            onElementRetrieved = { elem -> select.selectInRegistrationPhase(unwrapTyped(elem)) },
+            onElementRetrieved = { elem -> select.selectInRegistrationPhase(elem) },
             onSuspend = { _, _, _ -> },
             onClosed = { onClosedSelectOnReceive(select) }
         )

--- a/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/BufferedChannel.kt
@@ -1552,7 +1552,7 @@ internal open class BufferedChannel<E>(
 
     override fun iterator(): ChannelIterator<E> = BufferedChannelIterator()
 
-    override suspend fun emitAll(collector: FlowCollector<E>) {
+    internal suspend fun emitAllInternal(collector: FlowCollector<E>) {
         val iterator = iterator() as BufferedChannel.BufferedChannelIterator
         while (iterator.hasNext()) {
             collector.emitInternal(iterator.nextInternal())

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.channels.Channel.Factory.CHANNEL_DEFAULT_CAPACITY
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.selects.*
 import kotlin.contracts.*
@@ -287,6 +288,15 @@ public interface ReceiveChannel<out E> {
      * throws the original [close][SendChannel.close] cause exception if the channel has _failed_.
      */
     public operator fun iterator(): ChannelIterator<E>
+
+    /**
+     * Emits all elements of this channel using [collector].
+     */
+    public suspend fun emitAll(collector: FlowCollector<E>) {
+        for (element in this) {
+            collector.emit(element)
+        }
+    }
 
     /**
      * Cancels reception of remaining elements from this channel with an optional [cause].

--- a/kotlinx-coroutines-core/common/src/channels/Channel.kt
+++ b/kotlinx-coroutines-core/common/src/channels/Channel.kt
@@ -290,15 +290,6 @@ public interface ReceiveChannel<out E> {
     public operator fun iterator(): ChannelIterator<E>
 
     /**
-     * Emits all elements of this channel using [collector].
-     */
-    public suspend fun emitAll(collector: FlowCollector<E>) {
-        for (element in this) {
-            collector.emit(element)
-        }
-    }
-
-    /**
      * Cancels reception of remaining elements from this channel with an optional [cause].
      * This function closes the channel and removes all buffered sent elements from it.
      *

--- a/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
+++ b/kotlinx-coroutines-core/common/src/channels/ChannelCoroutine.kt
@@ -1,6 +1,8 @@
 package kotlinx.coroutines.channels
 
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.emitAllInternal
 import kotlin.coroutines.*
 
 internal open class ChannelCoroutine<E>(
@@ -34,5 +36,9 @@ internal open class ChannelCoroutine<E>(
         val exception = cause.toCancellationException()
         _channel.cancel(exception) // cancel the channel
         cancelCoroutine(exception) // cancel the job
+    }
+
+    internal suspend fun emitAllInternal(flowCollector: FlowCollector<E>) {
+        emitAllInternal(_channel, flowCollector)
     }
 }

--- a/kotlinx-coroutines-core/common/src/flow/Channels.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Channels.kt
@@ -29,7 +29,7 @@ private suspend fun <T> FlowCollector<T>.emitAllImpl(channel: ReceiveChannel<T>,
     ensureActive()
     var cause: Throwable? = null
     try {
-        emitAll(channel, this)
+        emitAllInternal(channel, this)
     } catch (e: Throwable) {
         cause = e
         throw e
@@ -38,10 +38,13 @@ private suspend fun <T> FlowCollector<T>.emitAllImpl(channel: ReceiveChannel<T>,
     }
 }
 
-private suspend fun <T> emitAll(channel: ReceiveChannel<T>, collector: FlowCollector<T>) {
+internal suspend fun <T> emitAllInternal(channel: ReceiveChannel<T>, collector: FlowCollector<T>) {
     when (channel) {
         is BufferedChannel<*> -> {
             (channel as BufferedChannel<T>).emitAllInternal(collector)
+        }
+        is ChannelCoroutine<*> -> {
+            (channel as ChannelCoroutine<T>).emitAllInternal(collector)
         }
         else -> {
             for (element in channel) {

--- a/kotlinx-coroutines-core/common/src/flow/Channels.kt
+++ b/kotlinx-coroutines-core/common/src/flow/Channels.kt
@@ -29,9 +29,7 @@ private suspend fun <T> FlowCollector<T>.emitAllImpl(channel: ReceiveChannel<T>,
     ensureActive()
     var cause: Throwable? = null
     try {
-        for (element in channel) {
-            emit(element)
-        }
+        channel.emitAll(this)
     } catch (e: Throwable) {
         cause = e
         throw e

--- a/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/SharedFlow.kt
@@ -389,16 +389,11 @@ internal open class SharedFlowImpl<T>(
                     awaitValue(slot) // await signal that the new value is available
                 }
                 collectorJob?.ensureActive()
-                emitInner(collector, newValue as T)
+                collector.emitInternal(newValue as T)
             }
         } finally {
             freeSlot(slot)
         }
-    }
-
-    // Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
-    private suspend fun emitInner(collector: FlowCollector<T>, value: T) {
-        collector.emit(unwrapInternal(value))
     }
 
     override fun tryEmit(value: T): Boolean {

--- a/kotlinx-coroutines-core/common/src/flow/StateFlow.kt
+++ b/kotlinx-coroutines-core/common/src/flow/StateFlow.kt
@@ -394,7 +394,7 @@ private class StateFlowImpl<T>(
                 collectorJob?.ensureActive()
                 // Conflate value emissions using equality
                 if (oldState == null || oldState != newState) {
-                    emitInner(collector, newState)
+                    collector.emitInternal(newState)
                     oldState = newState
                 }
                 // Note: if awaitPending is cancelled, then it bails out of this loop and calls freeSlot
@@ -405,11 +405,6 @@ private class StateFlowImpl<T>(
         } finally {
             freeSlot(slot)
         }
-    }
-
-    // Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
-    private suspend fun emitInner(collector: FlowCollector<T>, newState: Any) {
-        collector.emit(NULL.unbox(newState))
     }
 
     override fun createSlot() = StateFlowSlot()

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
@@ -36,10 +36,10 @@ private fun unwrapInternalDebuggerCapture(value: Any?): Any? {
 
 // Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
 internal suspend fun <T> FlowCollector<T>.emitInternal(value: Any?) {
-    debuggerCapture<T, Unit>(value) { emit(it) }
+    emit(unwrapTyped<T>(value))
 }
 
 // Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
 internal suspend fun <Unwrapped, R> debuggerCapture(value: Any?, block: suspend (Unwrapped) -> R): R {
-    return block(unwrapTyped<Unwrapped>(value))
+    return block(unwrapInternal(value) as Unwrapped)
 }

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
@@ -1,4 +1,8 @@
+@file:Suppress("UNCHECKED_CAST")
+
 package kotlinx.coroutines.flow.internal
+
+import kotlinx.coroutines.flow.FlowCollector
 
 /**
  * Used by IDEA debugger agent to support asynchronous stack traces in flows.
@@ -11,12 +15,40 @@ internal class FlowValueWrapperInternal<T>(val value: T)
 internal fun <T> wrapInternal(value: T): T = value
 internal fun <T> unwrapInternal(value: T): T = value
 
-// debugger agent transforms wrapInternal so it returns wrapInternalDebuggerCapture(value) instead of just value
-private fun wrapInternalDebuggerCapture(value: Any?): Any = FlowValueWrapperInternal(value)
+// debugger agent transforms wrapInternal so it returns wrapInternalDebuggerCaptureX(value) instead of just value.
+// "X" may be Strict or Lenient, debugger agent picks one depending on its arguments.
+// Both versions are aimed at handling double wrapping, which is always an error;
+// a lenient version swallows it, allowing the application to proceed normally
+// at the cost of not working async stack traces in the place;
+// a strict version throws an exception so that the issue could be traced at its earliest point
+
+private fun wrapInternalDebuggerCaptureStrict(value: Any?): Any {
+    if (value is FlowValueWrapperInternal<*>) {
+        throw DoubleWrappingException("Double-wrapping detected; failing fast. This should never happen!")
+    }
+    return FlowValueWrapperInternal(value)
+}
+
+private fun wrapInternalDebuggerCaptureLenient(value: Any?): Any {
+    if (value is FlowValueWrapperInternal<*>) {
+        return value
+    }
+    return FlowValueWrapperInternal(value)
+}
 
 // debugger agent transforms unwrapInternal so it returns unwrapInternalDebuggerCapture(value) instead of just value
 //
 // normally, value is always FlowValueWrapperInternal, but potentially instrumentation may start
 // in the middle of the execution (for example, when the debugger was attached to a running application),
 // and the emitted value hadn't been wrapped
-private fun unwrapInternalDebuggerCapture(value: Any?): Any? = (value as? FlowValueWrapperInternal<*>)?.value ?: value
+private fun unwrapInternalDebuggerCapture(value: Any?): Any? {
+    val wrapper = value as? FlowValueWrapperInternal<*> ?: return value
+    return wrapper.value
+}
+
+// Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
+internal suspend fun <T> FlowCollector<T>.emitInternal(value: Any?) {
+    emit(NULL.unbox(unwrapInternal(value)))
+}
+
+private class DoubleWrappingException(message: String) : RuntimeException(message)

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
@@ -14,6 +14,7 @@ internal class FlowValueWrapperInternal<T>(val value: T)
 
 internal fun <T> wrapInternal(value: T): T = value
 internal fun <T> unwrapInternal(value: T): T = value
+internal fun <T> unwrapTyped(value: Any?): T = NULL.unbox(unwrapInternal(value))
 
 // debugger agent transforms wrapInternal so it returns wrapInternalDebuggerCapture(value) instead of just value.
 private fun wrapInternalDebuggerCapture(value: Any?): Any {
@@ -35,5 +36,5 @@ private fun unwrapInternalDebuggerCapture(value: Any?): Any? {
 
 // Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
 internal suspend fun <T> FlowCollector<T>.emitInternal(value: Any?) {
-    emit(NULL.unbox(unwrapInternal(value)))
+    emit(unwrapTyped<T>(value))
 }

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
@@ -15,21 +15,8 @@ internal class FlowValueWrapperInternal<T>(val value: T)
 internal fun <T> wrapInternal(value: T): T = value
 internal fun <T> unwrapInternal(value: T): T = value
 
-// debugger agent transforms wrapInternal so it returns wrapInternalDebuggerCaptureX(value) instead of just value.
-// "X" may be Strict or Lenient, debugger agent picks one depending on its arguments.
-// Both versions are aimed at handling double wrapping, which is always an error;
-// a lenient version swallows it, allowing the application to proceed normally
-// at the cost of not working async stack traces in the place;
-// a strict version throws an exception so that the issue could be traced at its earliest point
-
-private fun wrapInternalDebuggerCaptureStrict(value: Any?): Any {
-    if (value is FlowValueWrapperInternal<*>) {
-        throw DoubleWrappingException("Double-wrapping detected; failing fast. This should never happen!")
-    }
-    return FlowValueWrapperInternal(value)
-}
-
-private fun wrapInternalDebuggerCaptureLenient(value: Any?): Any {
+// debugger agent transforms wrapInternal so it returns wrapInternalDebuggerCapture(value) instead of just value.
+private fun wrapInternalDebuggerCapture(value: Any?): Any {
     if (value is FlowValueWrapperInternal<*>) {
         return value
     }
@@ -50,5 +37,3 @@ private fun unwrapInternalDebuggerCapture(value: Any?): Any? {
 internal suspend fun <T> FlowCollector<T>.emitInternal(value: Any?) {
     emit(NULL.unbox(unwrapInternal(value)))
 }
-
-private class DoubleWrappingException(message: String) : RuntimeException(message)

--- a/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
+++ b/kotlinx-coroutines-core/common/src/flow/internal/FlowValueWrapperInternal.kt
@@ -36,5 +36,10 @@ private fun unwrapInternalDebuggerCapture(value: Any?): Any? {
 
 // Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
 internal suspend fun <T> FlowCollector<T>.emitInternal(value: Any?) {
-    emit(unwrapTyped<T>(value))
+    debuggerCapture<T, Unit>(value) { emit(it) }
+}
+
+// Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
+internal suspend fun <Unwrapped, R> debuggerCapture(value: Any?, block: suspend (Unwrapped) -> R): R {
+    return block(unwrapTyped<Unwrapped>(value))
 }

--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -209,10 +209,10 @@ private fun <T> Flow<T>.debounceInternal(timeoutMillisSelector: (T) -> Long): Fl
             var timeoutMillis = 0L // will be always computed when lastValue != null
             // Compute timeout for this value
             if (lastValue != null) {
-                timeoutMillis = timeoutMillisSelector(NULL.unbox(lastValue))
+                timeoutMillis = timeoutMillisSelector(NULL.unbox(unwrapInternal(lastValue)))
                 require(timeoutMillis >= 0L) { "Debounce timeout should not be negative" }
                 if (timeoutMillis == 0L) {
-                    emitInner(downstream, lastValue)
+                    downstream.emitInternal(lastValue)
                     lastValue = null // Consume the value
                 }
             }
@@ -223,7 +223,7 @@ private fun <T> Flow<T>.debounceInternal(timeoutMillisSelector: (T) -> Long): Fl
                 // Set timeout when lastValue exists and is not consumed yet
                 if (lastValue != null) {
                     onTimeout(timeoutMillis) {
-                        emitInner<T>(downstream, lastValue)
+                        downstream.emitInternal<T>(lastValue)
                         lastValue = null // Consume the value
                     }
                 }
@@ -233,18 +233,13 @@ private fun <T> Flow<T>.debounceInternal(timeoutMillisSelector: (T) -> Long): Fl
                         .onFailure {
                             it?.let { throw it }
                             // If closed normally, emit the latest value
-                            if (lastValue != null) emitInner<T>(downstream, lastValue)
+                            if (lastValue != null) downstream.emitInternal<T>(lastValue)
                             lastValue = DONE
                         }
                 }
             }
         }
     }
-
-// Shouldn't be inlined, the method is instrumented by the IDEA debugger agent
-private suspend fun <T> emitInner(downstream: FlowCollector<T>, value: Any?) {
-    downstream.emit(NULL.unbox(unwrapInternal(value)))
-}
 
 /**
  * Returns a flow that emits only the latest value emitted by the original flow during the given sampling [period][periodMillis].
@@ -295,7 +290,7 @@ public fun <T> Flow<T>.sample(periodMillis: Long): Flow<T> {
                 ticker.onReceive {
                     val value = lastValue ?: return@onReceive
                     lastValue = null // Consume the value
-                    emitInner(downstream, value)
+                    downstream.emitInternal(value)
                 }
             }
         }

--- a/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
+++ b/kotlinx-coroutines-core/common/src/flow/operators/Delay.kt
@@ -229,7 +229,7 @@ private fun <T> Flow<T>.debounceInternal(timeoutMillisSelector: (T) -> Long): Fl
                 }
                 values.onReceiveCatching { value ->
                     value
-                        .onSuccess { lastValue = it }
+                        .onSuccess { lastValue = wrapInternal(it) }
                         .onFailure {
                             it?.let { throw it }
                             // If closed normally, emit the latest value
@@ -278,7 +278,7 @@ public fun <T> Flow<T>.sample(periodMillis: Long): Flow<T> {
             select<Unit> {
                 values.onReceiveCatching { result ->
                     result
-                        .onSuccess { lastValue = it }
+                        .onSuccess { lastValue = wrapInternal(it) }
                         .onFailure {
                             it?.let { throw it }
                             ticker.cancel(ChildCancelledException())

--- a/kotlinx-coroutines-core/common/src/selects/Select.kt
+++ b/kotlinx-coroutines-core/common/src/selects/Select.kt
@@ -3,6 +3,8 @@ package kotlinx.coroutines.selects
 import kotlinx.atomicfu.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.*
+import kotlinx.coroutines.flow.internal.debuggerCapture
+import kotlinx.coroutines.flow.internal.wrapInternal
 import kotlinx.coroutines.internal.*
 import kotlinx.coroutines.selects.TrySelectDetailedResult.*
 import kotlin.contracts.*
@@ -626,7 +628,7 @@ internal open class SelectImplementation<R>(
                         val cont = curState as CancellableContinuation<Unit>
                         // Success! Store the resumption value and
                         // try to resume the continuation.
-                        this.internalResult = internalResult
+                        this.internalResult = wrapInternal(internalResult)
                         if (cont.tryResume(onCancellation)) return TRY_SELECT_SUCCESSFUL
                         // If the resumption failed, we need to clean the [result] field to avoid memory leaks.
                         this.internalResult = NO_RESULT
@@ -690,19 +692,21 @@ internal open class SelectImplementation<R>(
         // of memory leaks. Collect the internal result before that.
         val internalResult = this.internalResult
         cleanup(selectedClause)
-        // Process the internal result and invoke the user's block.
-        return if (!RECOVER_STACK_TRACES) {
-            // TAIL-CALL OPTIMIZATION: the `suspend` block
-            // is invoked at the very end.
-            val blockArgument = selectedClause.processResult(internalResult)
-            selectedClause.invokeBlock(blockArgument)
-        } else {
-            // TAIL-CALL OPTIMIZATION: the `suspend`
-            // function is invoked at the very end.
-            // However, internally this `suspend` function
-            // constructs a state machine to recover a
-            // possible stack-trace.
-            processResultAndInvokeBlockRecoveringException(selectedClause, internalResult)
+        return debuggerCapture<Any?, R>(internalResult) { result ->
+            // Process the internal result and invoke the user's block.
+            if (!RECOVER_STACK_TRACES) {
+                // TAIL-CALL OPTIMIZATION: the `suspend` block
+                // is invoked at the very end.
+                val blockArgument = selectedClause.processResult(result)
+                selectedClause.invokeBlock(blockArgument)
+            } else {
+                // TAIL-CALL OPTIMIZATION: the `suspend`
+                // function is invoked at the very end.
+                // However, internally this `suspend` function
+                // constructs a state machine to recover a
+                // possible stack-trace.
+                processResultAndInvokeBlockRecoveringException(selectedClause, result)
+            }
         }
     }
 


### PR DESCRIPTION
From the commit message:

---
* simplify instrumentation by making a single insertion point source instead of having one in every class
* handle a double-wrapping case which leads to errors; allow agent to choose how to handle it
* support more commonly used operators (such as `scan`, `buffer`, `debounce` with dynamic timeout)

Unfortunately, this change doesn't cover all possible scenarios of using flows, as many of them interoperate with `Channel`s, and it should be addressed separately.

---

Hi! I hope that's the latest addition to the fork from my side in the nearest future :)

The previous approach didn't work well on IDEA project, as working with flows there is often more complicated that just emit, debounce, and collect. There were also cases when affected code was failing because of double-wrapping.

This change is addressed to handle these issues. It's tested on IDEA and it works, yielding correct async stack traces.

But the most important part is error protection. Now the code checks possible double-wrappings and acts according to debugger agent settings: either proceed without wrapping or raise an unchecked exception and fail fast. In the end, I see all three options (these two and an ultimate option to not instrument flows at all) present in IDEA. For example, we might want to have fail-fast option by default to collect badly covered places and fix them later. The option without unwrapping might serve as a fallback option. Telling the agent to not instrument flows is a critical fallback people might want to use when, for example, async stack traces don't work in their cases and they don't want to waste CPU cycles on nothing.

---

Related change in debugger-agent: https://github.com/JetBrains/debugger-agent/pull/3